### PR TITLE
Export default in App.tsx to fix native crash

### DIFF
--- a/packages/app/App.tsx
+++ b/packages/app/App.tsx
@@ -3,13 +3,16 @@ import { StatusBar } from 'expo-status-bar';
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
-export const App: React.FC = () => (
+const App: React.FC = () => (
   <View style={styles.container}>
     <BaseComponent />
     <Text>Open up App.tsx to start working on your app!</Text>
     <StatusBar style="auto" />
   </View>
 )
+
+// eslint-disable-next-line import/no-default-export
+export default App;
 
 const styles = StyleSheet.create({
   // eslint-disable-next-line react-native/no-color-literals

--- a/packages/app/babel.config.js
+++ b/packages/app/babel.config.js
@@ -1,4 +1,4 @@
 // @generated: @expo/next-adapter@2.1.32
-// Learn more: https://github.com/expo/expo/blob/master/docs/pages/versions/unversioned/guides/using-nextjs.md#shared-steps
+// Learn more: https://github.com/expo/expo/blob/master/docs/pages/guides/using-nextjs.md
 
 module.exports = { presets: ['@expo/next-adapter/babel'] };

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "jsx": "react-native",
+    "jsx": "preserve",
     "lib": ["dom", "esnext"],
     "moduleResolution": "node",
     "noEmit": true,


### PR DESCRIPTION
The __generated__/AppEntry.js file expects App.tsx to export a default component. Had an ESLint rule to disable
default exports for most components / modules we write (https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/), but can be disabled for this entrypoint.