### PR TITLE
Feature/browser metamask

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,3 +11,6 @@ web-build
 # jest
 coverage
 
+
+# until we have finalized wrappers/types
+mfWeb3.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,6 +34,10 @@
     // Doesnt work for FC: https://github.com/yannickcr/eslint-plugin-react/issues/2353
     "react/prop-types": "off",
 
+    "react-native/no-raw-text": "off", // Is fine for react and web views that update text state
+    "no-shadow": "off", // Prevents state vars from same name local update vars check
+    "@typescript-eslint/no-shadow": ["error"],
+
     // Prefer non-default exports
     "import/no-default-export": "error",
     "import/prefer-default-export": "off",

--- a/packages/app/screens/Home.tsx
+++ b/packages/app/screens/Home.tsx
@@ -1,4 +1,4 @@
-import { PageContainer } from '@mf/components';
+import { MetamaskConnect, PageContainer } from '@mf/components';
 import { useWalletConnect } from '@walletconnect/react-native-dapp';
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
@@ -35,6 +35,9 @@ export const HomeScreen: React.FC<Props> = ({ navigation }) => {
           }}
         />
       )}
+
+      <MetamaskConnect />
+
       <StatusBar style="auto" />
     </PageContainer>
   );

--- a/packages/components/MetamaskConnect.tsx
+++ b/packages/components/MetamaskConnect.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import { Platform } from 'react-native';
+
+import { connectWallet, getCurrentWalletConnected } from './util/mfWeb3';
+import { ConnectedWallet } from './util/types';
+
+export const MetamaskConnect: React.FC = () => {
+  const [walletAddress, setWallet] = useState('');
+  const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    async function connectMetamask() {
+      const wallet: ConnectedWallet = await getCurrentWalletConnected();
+
+      setWallet(wallet.address);
+      setStatus(wallet.status);
+
+      addWalletListener();
+    }
+    connectMetamask();
+  }, []);
+
+  if (Platform.OS !== 'web') {
+    // Web only component, return early.
+    return null;
+  }
+
+  function addWalletListener() {
+    if (window.ethereum) {
+      window.ethereum.on('accountsChanged', (accounts) => {
+        if (accounts.length > 0) {
+          setWallet(accounts[0]);
+          setStatus('👆🏽 Connected.');
+        } else {
+          setWallet('');
+          setStatus('🦊 Connect to Metamask using the top right button.');
+        }
+      });
+    } else {
+      setStatus(
+        '🦊 - You must install Metamask, a virtual Ethereum wallet, in your browser.',
+      );
+    }
+  }
+
+  const connectWalletPressed = async () => {
+    const walletResponse = await connectWallet();
+    setStatus(walletResponse.status);
+    setWallet(walletResponse.address);
+  };
+
+  const containerStyle = {
+    display: 'flex',
+    flexDirection: 'column',
+  };
+
+  return (
+    <div className="MetamaskConnectWrapper" style={containerStyle}>
+      <button
+        type="button"
+        id="connectMetamaskButton"
+        onClick={connectWalletPressed}
+      >
+        {walletAddress.length > 0 ? (
+          `Connected: ${String(walletAddress).substring(0, 6)}...${String(
+            walletAddress,
+          ).substring(38)}`
+        ) : (
+          <span>Connect Wallet</span>
+        )}
+      </button>
+
+      <span>{`Wallet Status: ${status}`}</span>
+    </div>
+  );
+};

--- a/packages/components/MetamaskConnect.tsx
+++ b/packages/components/MetamaskConnect.tsx
@@ -5,8 +5,8 @@ import { connectWallet, getCurrentWalletConnected } from './util/mfWeb3';
 import { ConnectedWallet } from './util/types';
 
 export const MetamaskConnect: React.FC = () => {
-  const [walletAddress, setWallet] = useState('');
-  const [status, setStatus] = useState('');
+  const [walletAddress, setWallet] = React.useState('');
+  const [status, setStatus] = React.useState('');
 
   useEffect(() => {
     async function connectMetamask() {

--- a/packages/components/MetamaskConnect.tsx
+++ b/packages/components/MetamaskConnect.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Platform } from 'react-native';
+import { Button, Platform, Text, View } from 'react-native';
 
 import { connectWallet, getCurrentWalletConnected } from './util/mfWeb3';
 import { ConnectedWallet } from './util/types';
@@ -49,28 +49,25 @@ export const MetamaskConnect: React.FC = () => {
     setWallet(walletResponse.address);
   };
 
-  const containerStyle = {
-    display: 'flex',
-    flexDirection: 'column',
-  };
+  const buttonTitle =
+    walletAddress && walletAddress.length > 0 ? (
+      `Connected: ${String(walletAddress).substring(0, 6)}...${String(
+        walletAddress,
+      ).substring(38)}`
+    ) : (
+      <Text>Connect Wallet</Text>
+    );
 
   return (
-    <div className="MetamaskConnectWrapper" style={containerStyle}>
-      <button
+    <View className="MetamaskConnectWrapper">
+      <Button
         type="button"
         id="connectMetamaskButton"
-        onClick={connectWalletPressed}
-      >
-        {walletAddress.length > 0 ? (
-          `Connected: ${String(walletAddress).substring(0, 6)}...${String(
-            walletAddress,
-          ).substring(38)}`
-        ) : (
-          <span>Connect Wallet</span>
-        )}
-      </button>
+        onPress={connectWalletPressed}
+        title={buttonTitle}
+      />
 
-      <span>{`Wallet Status: ${status}`}</span>
-    </div>
+      <Text>{`Wallet Status: ${status}`}</Text>
+    </View>
   );
 };

--- a/packages/components/MetamaskConnect.tsx
+++ b/packages/components/MetamaskConnect.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { Button, Platform, Text, View } from 'react-native';
 
 import { connectWallet, getCurrentWalletConnected } from './util/mfWeb3';

--- a/packages/components/MetamaskConnect.tsx
+++ b/packages/components/MetamaskConnect.tsx
@@ -50,22 +50,15 @@ export const MetamaskConnect: React.FC = () => {
   };
 
   const buttonTitle =
-    walletAddress && walletAddress.length > 0 ? (
-      `Connected: ${String(walletAddress).substring(0, 6)}...${String(
-        walletAddress,
-      ).substring(38)}`
-    ) : (
-      <Text>Connect Wallet</Text>
-    );
+    walletAddress && walletAddress.length > 0
+      ? `Connected: ${String(walletAddress).substring(0, 6)}...${String(
+          walletAddress,
+        ).substring(38)}`
+      : 'Connect Wallet';
 
   return (
-    <View className="MetamaskConnectWrapper">
-      <Button
-        type="button"
-        id="connectMetamaskButton"
-        onPress={connectWalletPressed}
-        title={buttonTitle}
-      />
+    <View>
+      <Button onPress={connectWalletPressed} title={buttonTitle} />
 
       <Text>{`Wallet Status: ${status}`}</Text>
     </View>

--- a/packages/components/index.tsx
+++ b/packages/components/index.tsx
@@ -1,1 +1,2 @@
+export { MetamaskConnect } from './MetamaskConnect';
 export { PageContainer } from './PageContainer';

--- a/packages/components/util/mfWeb3.js
+++ b/packages/components/util/mfWeb3.js
@@ -5,7 +5,7 @@ export const connectWallet = async () => {
         method: 'eth_requestAccounts',
       });
       const obj = {
-        status: '👆🏽 Write a message in the text-field above.',
+        status: '👆🏽 Connected.',
         address: addressArray[0],
       };
       return obj;
@@ -43,7 +43,7 @@ export const getCurrentWalletConnected = async () => {
       if (addressArray.length > 0) {
         return {
           address: addressArray[0],
-          status: '👆🏽 Write a message in the text-field above.',
+          status: '👆🏽 Connected.',
         };
       } else {
         return {

--- a/packages/components/util/mfWeb3.js
+++ b/packages/components/util/mfWeb3.js
@@ -18,18 +18,8 @@ export const connectWallet = async () => {
   } else {
     return {
       address: '',
-      status: (
-        <span>
-          <p>
-            {' '}
-            🦊{' '}
-            <a target="_blank" href={`https://metamask.io/download.html`}>
-              You must install Metamask, a virtual Ethereum wallet, in your
-              browser.
-            </a>
-          </p>
-        </span>
-      ),
+      status:
+        '🦊 - You must install Metamask, a virtual Ethereum wallet, in your browser.',
     };
   }
 };

--- a/packages/components/util/mfWeb3.js
+++ b/packages/components/util/mfWeb3.js
@@ -1,0 +1,67 @@
+export const connectWallet = async () => {
+  if (window.ethereum) {
+    try {
+      const addressArray = await window.ethereum.request({
+        method: 'eth_requestAccounts',
+      });
+      const obj = {
+        status: '👆🏽 Write a message in the text-field above.',
+        address: addressArray[0],
+      };
+      return obj;
+    } catch (err) {
+      return {
+        address: '',
+        status: 'Err: ' + err.message,
+      };
+    }
+  } else {
+    return {
+      address: '',
+      status: (
+        <span>
+          <p>
+            {' '}
+            🦊{' '}
+            <a target="_blank" href={`https://metamask.io/download.html`}>
+              You must install Metamask, a virtual Ethereum wallet, in your
+              browser.
+            </a>
+          </p>
+        </span>
+      ),
+    };
+  }
+};
+
+export const getCurrentWalletConnected = async () => {
+  if (window.ethereum) {
+    try {
+      const addressArray = await window.ethereum.request({
+        method: 'eth_accounts',
+      });
+      if (addressArray.length > 0) {
+        return {
+          address: addressArray[0],
+          status: '👆🏽 Write a message in the text-field above.',
+        };
+      } else {
+        return {
+          address: '',
+          status: '🦊 Connect to Metamask using the top right button.',
+        };
+      }
+    } catch (err) {
+      return {
+        address: '',
+        status: '😥 ' + err.message,
+      };
+    }
+  } else {
+    return {
+      address: '',
+      status:
+        '🦊 - You must install Metamask, a virtual Ethereum wallet, in your browser.',
+    };
+  }
+};

--- a/packages/components/util/types.ts
+++ b/packages/components/util/types.ts
@@ -1,16 +1,17 @@
-import {
-  ProviderConnectInfo,
-  ProviderMessage,
-  ProviderRpcError,
-  RequestArguments,
-} from 'hardhat/types';
+// For now - no hardhat
+// import {
+//   ProviderConnectInfo,
+//   ProviderMessage,
+//   ProviderRpcError,
+//   RequestArguments,
+// } from 'hardhat/types';
 
 export interface EthereumEvent {
-  connect: ProviderConnectInfo;
-  disconnect: ProviderRpcError;
+  connect: any;
+  disconnect: any;
   accountsChanged: Array<string>;
   chainChanged: string;
-  message: ProviderMessage;
+  message: any;
 }
 
 type EventKeys = keyof EthereumEvent;
@@ -34,7 +35,7 @@ export interface Ethereumish {
     request: { method: string; params?: Array<any> },
     callback: (error: any, response: any) => void,
   ) => void;
-  sendAsync: (request: RequestArguments) => Promise<unknown>;
+  sendAsync: (request: any) => Promise<unknown>;
 }
 
 declare global {

--- a/packages/components/util/types.ts
+++ b/packages/components/util/types.ts
@@ -1,0 +1,49 @@
+import {
+  ProviderConnectInfo,
+  ProviderMessage,
+  ProviderRpcError,
+  RequestArguments,
+} from 'hardhat/types';
+
+export interface EthereumEvent {
+  connect: ProviderConnectInfo;
+  disconnect: ProviderRpcError;
+  accountsChanged: Array<string>;
+  chainChanged: string;
+  message: ProviderMessage;
+}
+
+type EventKeys = keyof EthereumEvent;
+type EventHandler<K extends EventKeys> = (event: EthereumEvent[K]) => void;
+
+export interface Ethereumish {
+  autoRefreshOnNetworkChange: boolean;
+  chainId: string;
+  isMetaMask?: boolean;
+  isStatus?: boolean;
+  networkVersion: string;
+  selectedAddress: any;
+
+  on<K extends EventKeys>(event: K, eventHandler: EventHandler<K>): void;
+  enable(): Promise<any>;
+  request?: (request: { method: string; params?: Array<any> }) => Promise<any>;
+  /**
+   * @deprecated
+   */
+  send?: (
+    request: { method: string; params?: Array<any> },
+    callback: (error: any, response: any) => void,
+  ) => void;
+  sendAsync: (request: RequestArguments) => Promise<unknown>;
+}
+
+declare global {
+  interface Window {
+    ethereum: Ethereumish;
+  }
+}
+
+export type ConnectedWallet = {
+  address: string;
+  status: string;
+};


### PR DESCRIPTION
Basic button & library connection for browser metamask.

Notes:
- We can implement any provider inside the /util folder and it should be mostly drop in/drop out.
- We can add types as we build out specific providers, although I think with window.ethereum being the standard now, we can likely rely on that with our own custom providers for ceramic and ID contracts.
- Only appears and is functional in web, but written with react-native components to ensure parse-ability.