### PR TITLE
Setup functions to generate access codes for permissioned drops

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,10 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
-    open-pull-requests-limit: 10
+      interval: 'monthly'
+    open-pull-requests-limit: 15
+    ignore:
+      - dependency-name: '@types/*'
+      # For all packages, ignore all patch updates
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']

--- a/packages/services/.eslintrc.json
+++ b/packages/services/.eslintrc.json
@@ -12,7 +12,8 @@
       "files": ["./api/*.ts"],
       "rules": {
         "import/no-default-export": "off", // API routes have to have a default export
-        "import/prefer-default-export": "error"
+        "import/prefer-default-export": "error",
+        "@typescript-eslint/explicit-module-boundary-types": "off"
       }
     }
   ]

--- a/packages/services/.gitignore
+++ b/packages/services/.gitignore
@@ -1,1 +1,3 @@
 .vercel
+**/coverage
+.env

--- a/packages/services/api/generateProductAccessCode.ts
+++ b/packages/services/api/generateProductAccessCode.ts
@@ -6,7 +6,14 @@ import { CONFIG } from '../utils/config';
 import { getOrCreateLock } from '../utils/lockHelpers';
 import { isValidAuthToken } from '../utils/userHelpers';
 
-// Locksmith used to generate secret links: https://docs.uselocksmith.com/article/166-secret-link-keys
+// Allows an authenticated API user to generate access codes for a given product lock and customer ETH address.
+// Uses basic auth to protect the API. Saving the mapping of user to access code in the database to prevent the
+// same user from generating multiple codes.
+//
+// Product lock must first be created in the Locksmith app in Shopify, then the script to generate access codes should
+// be run which will insert the codes and lockId into the database. These generated codes should then be pasted into
+// the product lock page in Locksmith, ensuring the condition is (gives passcode AND liquid {% if request.page_type == "product" %}).
+// https://docs.uselocksmith.com/article/166-secret-link-keys
 export default async (req: VercelRequest, res: VercelResponse) => {
   const { isValid } = await isValidAuthToken(req.headers.authorization);
 

--- a/packages/services/api/generateProductAccessCode.ts
+++ b/packages/services/api/generateProductAccessCode.ts
@@ -1,0 +1,50 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import fetch from 'node-fetch';
+
+import { LocksmithLockResponse } from '../types/locksmith';
+import { CONFIG } from '../utils/config';
+import { getOrCreateLock } from '../utils/lockHelpers';
+import { isValidAuthToken } from '../utils/userHelpers';
+
+// Locksmith used to generate secret links: https://docs.uselocksmith.com/article/166-secret-link-keys
+export default async (req: VercelRequest, res: VercelResponse) => {
+  const { isValid } = await isValidAuthToken(req.headers.authorization);
+
+  if (!isValid) {
+    res.status(401).send('Unauthorized');
+    return;
+  }
+
+  let { lockId, ethAddress } = req.query;
+
+  if (!lockId || !ethAddress) {
+    res.status(400).send('Must provide lockId and ethAddress');
+    return;
+  }
+
+  if (typeof lockId !== 'string') [lockId] = lockId;
+  if (typeof ethAddress !== 'string') [ethAddress] = ethAddress;
+
+  const userLock = await getOrCreateLock(lockId, ethAddress);
+
+  if (!userLock) {
+    res.status(404).send('Unable to find product or no codes remaining');
+    return;
+  }
+
+  const response = await fetch(`${CONFIG.locksmithEndpoint}/locks/${lockId}`, {
+    headers: {
+      'x-shopify-shop-domain': CONFIG.shopDomain,
+      'x-locksmith-access-token': CONFIG.locksmithAccessToken,
+    },
+  });
+
+  const data = (await response.json()) as LocksmithLockResponse;
+
+  res.json({
+    // eslint-disable-next-line no-underscore-dangle
+    url: data._resource_url,
+    accessCode: userLock.access_code,
+    customerEthAddress: userLock.customer_eth_address,
+  });
+};

--- a/packages/services/api/hasuraAuthWebhook.ts
+++ b/packages/services/api/hasuraAuthWebhook.ts
@@ -1,0 +1,27 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { isValidAuthToken } from '../utils/userHelpers';
+
+const unauthorizedVariables = {
+  'X-Hasura-Role': 'public',
+};
+
+export default async (req: VercelRequest, res: VercelResponse) => {
+  try {
+    const { isValid, username } = await isValidAuthToken(
+      req.headers.authorization,
+    );
+
+    if (!isValid) {
+      res.json(unauthorizedVariables);
+      return;
+    }
+
+    res.json({
+      'X-Hasura-Role': 'api-user',
+      'X-Hasura-Username': username,
+    });
+  } catch (e) {
+    res.status(500).send('Unable to authenticate');
+  }
+};

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -8,9 +8,16 @@
   },
   "dependencies": {
     "@vercel/node": "1.11.1",
-    "cross-env": "5.0.5"
+    "bcrypt": "^5.0.1",
+    "dotenv": "^10.0.0",
+    "graphql": "^15.5.1",
+    "graphql-request": "^3.5.0",
+    "node-fetch": "^2.6.1",
+    "shortid": "^2.2.16"
   },
   "devDependencies": {
+    "@types/bcrypt": "^5.0.0",
+    "@types/shortid": "^0.0.29",
     "vercel": "^23.0.1"
   }
 }

--- a/packages/services/scripts/hashPassword.ts
+++ b/packages/services/scripts/hashPassword.ts
@@ -1,0 +1,12 @@
+import bcrypt from 'bcrypt';
+
+const SALT_ROUNDS = 5;
+
+async function hashPassword() {
+  const [password] = process.argv.slice(2);
+
+  const hash = await bcrypt.hash(password, SALT_ROUNDS);
+  console.log({ hash });
+}
+
+hashPassword();

--- a/packages/services/scripts/insertAccessCodes.ts
+++ b/packages/services/scripts/insertAccessCodes.ts
@@ -1,0 +1,57 @@
+import { gql } from 'graphql-request';
+import shortid from 'shortid';
+
+import { client } from '../utils/hasuraClient';
+
+const NUM_CODES = 250;
+
+const INSERT_CODES_MUTATION = gql`
+  mutation InsertAccessCodes($locks: [shop_product_locks_insert_input!]!) {
+    locks: insert_shop_product_locks(objects: $locks) {
+      affected_rows
+      returning {
+        access_code
+      }
+    }
+  }
+`;
+
+type LockInput = {
+  access_code: string;
+  lock_id: string;
+};
+
+type InsertCodesResponse = {
+  locks: {
+    affected_rows: number;
+    returning: Array<{ access_code: string }>;
+  };
+};
+
+// yarn ts-node ./scripts/insertAccessCodes <lockId>
+async function insertAccessCodes() {
+  const [lockId] = process.argv.slice(2);
+
+  if (!lockId) throw new Error('Must provide lockId');
+
+  const locks: LockInput[] = [];
+
+  for (let i = 0; i < NUM_CODES; i += 1) {
+    locks.push({ access_code: shortid.generate(), lock_id: lockId });
+  }
+
+  const claimedLockData = await client.request<InsertCodesResponse>(
+    INSERT_CODES_MUTATION,
+    {
+      locks,
+    },
+  );
+
+  console.log(
+    claimedLockData.locks.returning.map((l) => l.access_code).join('\n'),
+  );
+
+  console.log(`Created ${claimedLockData.locks.affected_rows} locks`);
+}
+
+insertAccessCodes();

--- a/packages/services/types/locksmith.ts
+++ b/packages/services/types/locksmith.ts
@@ -1,0 +1,55 @@
+export interface LocksmithLockResponse {
+  _id: number;
+  _title: string;
+  _has_resource: boolean;
+  _resource_path: string;
+  _resource_url: string;
+  _resource_admin_url: string;
+  _resource_type_for_humans: string;
+  _resource_description: string;
+  _updated_at: string;
+  _notices: Notice[];
+  resource_id: number;
+  resource_type: string;
+  resource_options: Record<string, unknown>;
+  enabled: boolean;
+  options: Options;
+  keys: Key[];
+}
+
+interface Notice {
+  status: string;
+  title: string;
+  description: string;
+}
+
+interface Options {
+  hide_links_to_resource: boolean;
+  hide_resource: boolean;
+  hide_resource_from_sitemaps: boolean;
+  manual: boolean;
+  noindex: boolean;
+  passcode_prompt: string;
+}
+
+interface Key {
+  _id: number;
+  options: Record<string, unknown>;
+  conditions: Condition[];
+}
+
+interface Condition {
+  _id: number;
+  type: string;
+  inverse: boolean;
+  options: ConditionOptions;
+}
+
+interface ConditionOptions {
+  passcodes?: string[];
+  passcodes_single_use?: boolean;
+  input_masked?: boolean;
+  customer_remember?: boolean;
+  liquid_condition?: string;
+  liquid_prelude?: string;
+}

--- a/packages/services/utils/arrayHelpers.ts
+++ b/packages/services/utils/arrayHelpers.ts
@@ -1,0 +1,3 @@
+export function getRandomElement<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}

--- a/packages/services/utils/config.ts
+++ b/packages/services/utils/config.ts
@@ -7,8 +7,6 @@ interface IConfig {
   locksmithAccessToken: string;
   locksmithEndpoint: string;
   shopDomain: string;
-  jwtIssuer: string;
-  jwtAudience: string;
 }
 
 function parseEnv<T extends string | number>(
@@ -30,6 +28,4 @@ export const CONFIG: IConfig = {
   locksmithAccessToken: parseEnv(process.env.LS_ACCESS_TOKEN),
   locksmithEndpoint: parseEnv(process.env.LS_ENDPOINT),
   shopDomain: parseEnv(process.env.SHOP_DOMAIN, 'metafactory.myshopify.com'),
-  jwtIssuer: parseEnv(process.env.JWT_ISSUER),
-  jwtAudience: parseEnv(process.env.JWT_AUDIENCE),
 };

--- a/packages/services/utils/config.ts
+++ b/packages/services/utils/config.ts
@@ -1,0 +1,35 @@
+// eslint-disable-next-line
+require('dotenv').config();
+
+interface IConfig {
+  graphqlURL: string;
+  graphqlAdminSecret: string;
+  locksmithAccessToken: string;
+  locksmithEndpoint: string;
+  shopDomain: string;
+  jwtIssuer: string;
+  jwtAudience: string;
+}
+
+function parseEnv<T extends string | number>(
+  v: string | undefined,
+  defaultValue?: T,
+): T {
+  if (v) {
+    return typeof defaultValue === 'number' ? (Number(v) as T) : (v as T);
+  }
+
+  if (!defaultValue) throw new Error('Missing ENV Variable');
+
+  return defaultValue;
+}
+
+export const CONFIG: IConfig = {
+  graphqlURL: parseEnv(process.env.GRAPHQL_URL),
+  graphqlAdminSecret: parseEnv(process.env.GRAPHQL_ADMIN_SECRET),
+  locksmithAccessToken: parseEnv(process.env.LS_ACCESS_TOKEN),
+  locksmithEndpoint: parseEnv(process.env.LS_ENDPOINT),
+  shopDomain: parseEnv(process.env.SHOP_DOMAIN, 'metafactory.myshopify.com'),
+  jwtIssuer: parseEnv(process.env.JWT_ISSUER),
+  jwtAudience: parseEnv(process.env.JWT_AUDIENCE),
+};

--- a/packages/services/utils/hasuraClient.ts
+++ b/packages/services/utils/hasuraClient.ts
@@ -1,0 +1,21 @@
+import { GraphQLClient } from 'graphql-request';
+
+import { CONFIG } from './config';
+
+interface GetClientParams {
+  role?: string;
+  userId?: string;
+  backendOnly?: boolean;
+}
+
+export const getClient = (params: GetClientParams = {}) =>
+  new GraphQLClient(CONFIG.graphqlURL, {
+    headers: {
+      'Content-Type': 'application/json',
+      'x-hasura-admin-secret': CONFIG.graphqlAdminSecret,
+      'x-hasura-role': params.role || 'admin',
+      'x-hasura-user-id': params.userId || '',
+    },
+  });
+
+export const client = getClient();

--- a/packages/services/utils/lockHelpers.ts
+++ b/packages/services/utils/lockHelpers.ts
@@ -1,0 +1,107 @@
+import { gql } from 'graphql-request';
+
+import { getRandomElement } from './arrayHelpers';
+import { client } from './hasuraClient';
+
+const GET_EXISTING_CODE_QUERY = gql`
+  query GetExistingAccessCode($ethAddress: String!, $lockId: String!) {
+    shop_product_locks(
+      where: {
+        _and: {
+          customer_eth_address: { _eq: $ethAddress }
+          lock_id: { _eq: $lockId }
+        }
+      }
+    ) {
+      access_code
+      customer_eth_address
+      lock_id
+    }
+  }
+`;
+
+const GET_NEW_CODE_QUERY = gql`
+  query GetNewAccessCode($lockId: String!) {
+    shop_product_locks(
+      where: {
+        _and: {
+          customer_eth_address: { _is_null: true }
+          lock_id: { _eq: $lockId }
+        }
+      }
+      limit: 20
+    ) {
+      access_code
+      lock_id
+    }
+  }
+`;
+
+const CLAIM_CODE_MUTATION = gql`
+  mutation ClaimCode(
+    $accessCode: String!
+    $lockId: String!
+    $ethAddress: String!
+  ) {
+    claimedLock: update_shop_product_locks_by_pk(
+      pk_columns: { access_code: $accessCode, lock_id: $lockId }
+      _set: { customer_eth_address: $ethAddress }
+    ) {
+      customer_eth_address
+      lock_id
+      access_code
+    }
+  }
+`;
+
+type ProductLock = {
+  access_code: string;
+  customer_eth_address?: string;
+  lock_id: string;
+};
+
+type GetCodeResponse = {
+  shop_product_locks?: Array<ProductLock>;
+};
+
+type ClaimCodeResponse = {
+  claimedLock?: ProductLock;
+};
+
+export const getOrCreateLock = async (
+  lockId: string,
+  ethAddress: string,
+): Promise<ProductLock | null> => {
+  const data = await client.request<GetCodeResponse>(GET_EXISTING_CODE_QUERY, {
+    ethAddress,
+    lockId,
+  });
+  const existingLock =
+    data && data.shop_product_locks && data.shop_product_locks[0];
+
+  if (existingLock) return existingLock;
+
+  const newCodeData = await client.request<GetCodeResponse>(
+    GET_NEW_CODE_QUERY,
+    {
+      lockId,
+    },
+  );
+
+  const newCodes = newCodeData.shop_product_locks || [];
+
+  if (!newCodes.length) return null;
+
+  const newCode = getRandomElement(newCodes);
+
+  const claimedLockData = await client.request<ClaimCodeResponse>(
+    CLAIM_CODE_MUTATION,
+    {
+      lockId: newCode.lock_id,
+      accessCode: newCode.access_code,
+      ethAddress,
+    },
+  );
+
+  return claimedLockData.claimedLock || null;
+};

--- a/packages/services/utils/userHelpers.ts
+++ b/packages/services/utils/userHelpers.ts
@@ -1,0 +1,59 @@
+import bcrypt from 'bcrypt';
+import { gql } from 'graphql-request';
+
+import { client } from './hasuraClient';
+
+const GET_API_USER_QUERY = gql`
+  query GetApiUser($username: String!) {
+    user: shop_api_users_by_pk(username: $username) {
+      password_hash
+    }
+  }
+`;
+
+const GET_EXISTING_CODE_QUERY = gql`
+  query GetExistingAccessCode($address: String!, $lockId: String = "") {
+    shop_product_locks(
+      where: {
+        _and: {
+          customer_eth_address: { _eq: $address }
+          lock_id: { _eq: $lockId }
+        }
+      }
+    ) {
+      access_code
+      customer_eth_address
+      lock_id
+    }
+  }
+`;
+
+type GetApiUserResponse = {
+  user?: {
+    password_hash: string;
+  };
+};
+
+export const isValidAuthToken = async (
+  token: string | undefined,
+): Promise<{ isValid: boolean; username?: string }> => {
+  const authTokenReceived = (token || '').split(' ')[1] || '';
+
+  const [username, password] = Buffer.from(authTokenReceived, 'base64')
+    .toString()
+    .split(':');
+
+  const data = await client.request<GetApiUserResponse>(GET_API_USER_QUERY, {
+    username,
+  });
+  const savedHash = data && data.user && data.user.password_hash;
+
+  if (!savedHash) return { isValid: false };
+
+  const isValid = await bcrypt.compare(password, savedHash);
+
+  return {
+    isValid,
+    username,
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3227,6 +3227,21 @@
   dependencies:
     "@json-rpc-tools/types" "^1.6.1"
 
+"@mapbox/node-pre-gyp@^1.0.0":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz#2a0b32fcb416fb3f2250fd24cb2a81421a4f5950"
+  integrity sha512-4srsKPXWlIxp5Vbqz5uLfBN+du2fJChBoYn/f2h991WLdk7jUvcSk/McVLSv/X+xQIPI8eGD5GjrnygdyHnhPA==
+  dependencies:
+    detect-libc "^1.0.3"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.1"
+    nopt "^5.0.0"
+    npmlog "^4.1.2"
+    rimraf "^3.0.2"
+    semver "^7.3.4"
+    tar "^6.1.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -3719,6 +3734,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bcrypt@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/bcrypt/-/bcrypt-5.0.0.tgz#a835afa2882d165aff5690893db314eaa98b9f20"
+  integrity sha512-agtcFKaruL8TmcvqbndlqHPSJgsolhf/qPWchFlgnW1gECTN/nKbFcoFnvKAQRFfKbh+BO6A3SWdJu9t+xF3Lw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/bn.js@^4.11.3", "@types/bn.js@^4.11.5":
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
@@ -3975,6 +3997,11 @@
   integrity sha512-QMg+9v0bbNJ2peLuHRWxzmy0HRJIG6gFZNhaRSp7S3ggSbCCxiqQB2/ybvhXyhHOCequpNkrx7OavNhrWOsW0A==
   dependencies:
     "@types/node" "*"
+
+"@types/shortid@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/shortid/-/shortid-0.0.29.tgz#8093ee0416a6e2bf2aa6338109114b3fbffa0e9b"
+  integrity sha1-gJPuBBam4r8qpjOBCRFLP7/6Dps=
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -5618,6 +5645,14 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bcrypt@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-5.0.1.tgz#f1a2c20f208e2ccdceea4433df0c8b2c54ecdf71"
+  integrity sha512-9BTgmrhZM2t1bNuDtrtIMVSmmxZBrJ71n8Wg+YgdjHuIWYF7SjjmCPZFB+/5i/o/PIeRpwVJR3P+NrpIItUjqw==
+  dependencies:
+    "@mapbox/node-pre-gyp" "^1.0.0"
+    node-addon-api "^3.1.0"
+
 better-sqlite3@^7.1.2:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-7.4.1.tgz#9daab6fb5be44460772992478ccda2db53605b7d"
@@ -7040,15 +7075,7 @@ create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-cross-env@5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.0.5.tgz#4383d364d9660873dd185b398af3bfef5efffef3"
-  integrity sha1-Q4PTZNlmCHPdGFs5ivO/717//vM=
-  dependencies:
-    cross-spawn "^5.1.0"
-    is-windows "^1.0.0"
-
-cross-fetch@^3.0.4:
+cross-fetch@^3.0.4, cross-fetch@^3.0.6:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
   integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
@@ -7916,6 +7943,11 @@ dot-prop@^5.2.0:
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
   dependencies:
     is-obj "^2.0.0"
+
+dotenv@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -9235,6 +9267,11 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+extract-files@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-9.0.0.tgz#8a7744f2437f81f5ed3250ed9f1550de902fe54a"
+  integrity sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -10160,6 +10197,15 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
+graphql-request@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-3.5.0.tgz#7e69574e15875fb3f660a4b4be3996ecd0bbc8b7"
+  integrity sha512-Io89QpfU4rqiMbqM/KwMBzKaDLOppi8FU8sEccCE4JqCgz95W9Q8bvxQ4NfPALLSMvg9nafgg8AkYRmgKSlukA==
+  dependencies:
+    cross-fetch "^3.0.6"
+    extract-files "^9.0.0"
+    form-data "^3.0.0"
+
 graphql-tools@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-3.0.0.tgz#ff22ad15315fc268de8639d03936b911d78b9e9b"
@@ -10177,6 +10223,11 @@ graphql@0.13.2:
   integrity sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==
   dependencies:
     iterall "^1.2.1"
+
+graphql@^15.5.1:
+  version "15.5.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.1.tgz#f2f84415d8985e7b84731e7f3536f8bb9d383aad"
+  integrity sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -11376,7 +11427,7 @@ is-weakset@^2.0.1:
   resolved "https://registry.yarnpkg.com/is-weakset/-/is-weakset-2.0.1.tgz#e9a0af88dbd751589f5e50d80f4c98b780884f83"
   integrity sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw==
 
-is-windows@^1.0.0, is-windows@^1.0.2:
+is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
@@ -13249,7 +13300,7 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.0, make-dir@^3.0.2:
+make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -14040,6 +14091,11 @@ nano-json-stream-parser@^0.1.2:
   resolved "https://registry.yarnpkg.com/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz#0cc8f6d0e2b622b479c40d499c46d64b755c6f5f"
   integrity sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=
 
+nanoid@^2.1.0:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
+  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
+
 nanoid@^3.1.15, nanoid@^3.1.22:
   version "3.1.23"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
@@ -14255,12 +14311,17 @@ node-addon-api@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
+node-addon-api@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
 node-fetch@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
-node-fetch@2.6.1, node-fetch@^2.2.0, node-fetch@^2.6.0:
+node-fetch@2.6.1, node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -17591,6 +17652,13 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+shortid@^2.2.16:
+  version "2.2.16"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.16.tgz#b742b8f0cb96406fd391c76bfc18a67a57fe5608"
+  integrity sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==
+  dependencies:
+    nanoid "^2.1.0"
 
 side-channel@^1.0.3, side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Allows an authenticated API user to generate access codes for a given product lock and customer ETH address.
Used basic auth to protect the API. Saving the mapping of user to access code in the database to prevent the
same user from generating multiple codes.

Product lock must first be created in the Locksmith app in Shopify, then the script to generate access codes should
be run which will insert the codes and lockId into the database. These generated codes should then be pasted into
the product lock page in Locksmith, ensuring the condition is (gives passcode AND liquid {% if request.page_type == "product" %}).